### PR TITLE
Bevy 18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_state_ui"
-version = "0.6.0"
-edition = "2021"
+version = "0.7.0"
+edition = "2024"
 description = "A simple UI library for rendering a UI from a given state"
 repository = "https://github.com/ironpeak/bevy_state_ui"
 authors = ["Hrafn Orri Hrafnkelsson <hrafn@vidfjord.is>"]
@@ -11,10 +11,10 @@ keywords = ["gamedev", "ui", "bevy"]
 categories = ["game-development"]
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = ["bevy_ui"] }
+bevy = { version = "0.18", default-features = false, features = ["bevy_ui"] }
 
 [dev-dependencies]
-bevy = { version = "0.17" }
+bevy = { version = "0.18" }
 
 [[example]]
 name = "simple"

--- a/README.md
+++ b/README.md
@@ -6,52 +6,51 @@ Instead of manually managing UI entities, you declare your state and its `render
 
 ## Features
 
-* Declarative: define your UI based on a state struct.
-* Efficient: only re-renders UI when the state hash changes.
-* Familiar: integrates seamlessly with Bevy’s ECS and UI system.
-* Simple: minimal API, easy to get started.
+- Declarative: define your UI based on a state struct.
+- Efficient: only re-renders UI when the state hash changes.
+- Familiar: integrates seamlessly with Bevy’s ECS and UI system.
+- Simple: minimal API, easy to get started.
 
 ## Installation
 
 Add to your `Cargo.toml`:
 
-~~~toml
+```toml
 [dependencies]
-bevy_state_ui = "0.5"
-~~~
+bevy_state_ui = "0.7"
+```
 
 ## Example
 
-Here’s a minimal app with a button that changes appearance when hovered:
+Here’s a minimal app with clickable text that increments a counter:
 
 [examples/simple.rs](examples/simple.rs)
 
-
 Run it with:
 
-~~~bash
+```bash
 cargo run --example simple
-~~~
+```
 
 ## Why use this instead of plain Bevy UI?
 
 Normally in Bevy, building UI means:
 
-* Spawning a hierarchy of `Node`/`Text`/`Button` entities in startup systems.
-* Keeping track of `Entity` IDs or `Querys` to update them later.
-* Writing update logic that mutates styles, colors, and text when game state changes.
+- Spawning a hierarchy of `Node`/`Text`/`Button` entities in startup systems.
+- Keeping track of `Entity` IDs or `Querys` to update them later.
+- Writing update logic that mutates styles, colors, and text when game state changes.
 
 This often leads to boilerplate and imperative code. For example:
 
-* You check a `Res<State>` inside systems.
-* You manually update the `BackgroundColor` of a button when `state.hovered` changes.
-* You may need to despawn/respawn UI trees when state transitions are large.
+- You check a `Res<State>` inside systems.
+- You manually update the `BackgroundColor` of a button when `state.hovered` changes.
+- You may need to despawn/respawn UI trees when state transitions are large.
 
 With bevy_state_ui, you flip the model:
 
-* Define your UI as a pure function of state (`impl StateRender for State`).
-* The library automatically detects when state changes (via hashing).
-* The old UI is despawned and re-rendered from the new state.
+- Define your UI as a pure function of state (`impl StateRender for State`).
+- The library automatically detects when state changes (via hashing).
+- The old UI is despawned and re-rendered from the new state.
 
 This means:
 
@@ -63,13 +62,13 @@ If your mental model of UI is "render(state) → tree of UI nodes", this library
 
 ## How it works
 
-* You define a `State` struct that implements:
-  * `Resource` (so it can live in the ECS world).
-  * `Hash` (to efficiently detect when state changes).
-  * `StateRender` (your declarative UI description).
-* The system `ui_state_render::<State>`:
-  * Computes a hash of the state each frame.
-  * If it changed, despawns the previous UI root and calls your `render` function.
-  * Keeps the UI automatically in sync with your state.
+- You define a `State` struct that implements:
+  - `Resource` (so it can live in the ECS world).
+  - `Hash` (to efficiently detect when state changes).
+  - `StateRender` (your declarative UI description).
+- The system `ui_state_render::<State>`:
+  - Computes a hash of the state each frame.
+  - If it changed, despawns the previous UI root and calls your `render` function.
+  - Keeps the UI automatically in sync with your state.
 
 This lets you think of UI as a pure function of state, much like React, Elm, or SwiftUI.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,36 +3,34 @@ use bevy_state_ui::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins
-            .set(ImagePlugin::default_nearest())
-            .set(WindowPlugin {
-                primary_window: Some(Window {
-                    title: "Simple'".to_string(),
-                    present_mode: PresentMode::Immediate,
-                    ..default()
-                }),
+        .add_plugins((DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "Simple'".to_string(),
+                present_mode: PresentMode::Immediate,
                 ..default()
-            }),))
+            }),
+            ..default()
+        }),))
         .add_systems(Startup, setup)
-        .add_systems(Update, update_button_interactions)
         .add_systems(Update, ui_state_render::<State>)
         .register_ui_state::<State>()
         .run();
 }
 
 fn setup(mut commands: Commands) {
-    commands.insert_resource(State { hovered: false });
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2d);
+    commands.init_resource::<State>();
 }
 
-#[derive(Resource, Hash)]
+#[derive(Resource, Hash, Debug, Default)]
 pub struct State {
-    pub hovered: bool,
+    pub count: u128,
 }
 
 impl StateRender for State {
     fn render(&self, mut commands: EntityCommands) {
-        info!("render");
+        info!("UI Rendered!");
+        info!("{self:?}");
 
         commands
             .insert(Node {
@@ -41,63 +39,42 @@ impl StateRender for State {
                 ..default()
             })
             .with_children(|parent| {
+                parent.spawn((
+                    Text::new(format!("Count: {}", self.count)),
+                    TextColor::WHITE,
+                    Node {
+                        position_type: PositionType::Absolute,
+                        top: percent(42.5),
+                        left: percent(35),
+                        ..default()
+                    },
+                ));
+
                 parent
                     .spawn((
+                        Text::new("Click me to increment the Count!"),
                         Node {
-                            width: Val::Percent(40.0),
-                            height: Val::Percent(15.0),
-                            top: Val::Percent(42.5),
-                            left: Val::Percent(30.0),
-                            justify_content: JustifyContent::Center,
                             position_type: PositionType::Absolute,
-                            align_items: AlignItems::Center,
+                            top: percent(50),
+                            left: percent(35),
                             ..default()
                         },
-                        BackgroundColor(if self.hovered {
-                            Color::srgb(1.0, 1.0, 1.0).into()
-                        } else {
-                            Color::srgb(0.0, 0.0, 0.0).into()
-                        }),
-                        Button { ..default() },
-                        if self.hovered {
-                            Interaction::Hovered
-                        } else {
-                            Interaction::None
-                        },
                     ))
-                    .with_children(|parent| {
-                        parent.spawn((
-                            Text::new("I am a button"),
-                            TextColor(if !self.hovered {
-                                Color::srgb(1.0, 1.0, 1.0).into()
-                            } else {
-                                Color::srgb(0.0, 0.0, 0.0).into()
-                            }),
-                            TextFont {
-                                font_size: 40.0,
-                                ..default()
-                            },
-                        ));
-                    });
+                    .observe(on_click)
+                    .observe(|out: On<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
+                        let mut text_color = texts.get_mut(out.entity).unwrap();
+                        text_color.0 = Color::WHITE;
+                    })
+                    .observe(
+                        |over: On<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
+                            let mut color = texts.get_mut(over.entity).unwrap();
+                            color.0 = bevy::color::palettes::tailwind::CYAN_400.into();
+                        },
+                    );
             });
     }
 }
 
-fn update_button_interactions(
-    mut state: ResMut<State>,
-    q_interaction: Query<&Interaction, (Changed<Interaction>, With<Button>)>,
-) {
-    if q_interaction.is_empty() {
-        return;
-    }
-    for interaction in &q_interaction {
-        match interaction {
-            Interaction::Pressed | Interaction::Hovered => {
-                state.hovered = true;
-            }
-            Interaction::None => {
-                state.hovered = false;
-            }
-        }
-    }
+fn on_click(_click: On<Pointer<Click>>, mut state: ResMut<State>) {
+    state.count += 1;
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     marker::PhantomData,
-    u64,
 };
 
 use bevy::{diagnostic::FrameCount, platform::hash::FixedState, prelude::*};
@@ -38,7 +37,7 @@ impl StateUiAppExt for App {
         TState: Resource,
     {
         self.insert_resource(RenderedHash::<TState> {
-            phantom: PhantomData::default(),
+            phantom: PhantomData,
             last_frame_check: 0,
             last_hash_value: 0,
         });
@@ -67,9 +66,7 @@ pub fn ui_state_render<TState>(
         return;
     }
 
-    let mut hasher = FixedState::default().build_hasher();
-    state.hash(&mut hasher);
-    let value = hasher.finish();
+    let value = FixedState::default().hash_one(&*state);
 
     if hash.last_hash_value == value {
         return;
@@ -83,7 +80,7 @@ pub fn ui_state_render<TState>(
     }
 
     let commands = commands.spawn(RootNode::<TState> {
-        phantom: PhantomData::default(),
+        phantom: PhantomData,
     });
 
     state.render(commands);


### PR DESCRIPTION
1. Bumped to Bevy 18
2. Linted lib.rs; no functional changes
3. Reworked the example using Bevy's updated version of "picking". Your current example uses outdated click and hover techniques.
4. Deleted the nightly rust toolchain; there are no experimental features here so it is not needed
5. Updated and formatted readme

Cool project. Will be using it for my ELM-style Bevy template, inspired by Iced.