### PR TITLE
Release 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_state_ui"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "A simple UI library for rendering a UI from a given state"
 repository = "https://github.com/ironpeak/bevy_state_ui"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # bevy_state_ui
 
-A simple UI library for [Bevy](https://bevy.org) that renders UI directly from application state.
-
-Instead of manually managing UI entities, you declare your state and its `render` function, and `bevy_state_ui` will automatically keep the UI in sync whenever the state changes.
+A simple Bevy plugin that re-renders UI from application state. Define your UI as a function of state, and the plugin handles the rest.
 
 ## Features
 
-- Declarative: define your UI based on a state struct.
-- Efficient: only re-renders UI when the state hash changes.
-- Familiar: integrates seamlessly with Bevy’s ECS and UI system.
-- Simple: minimal API, easy to get started.
+- **Declarative** - define UI based on a state struct, not imperative entity management.
+- **Reactive** - only re-renders when the state actually changes, using Bevy's built-in change detection.
+- **Simple** - minimal API surface: one trait, one plugin.
 
 ## Installation
 
@@ -17,58 +14,82 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy_state_ui = "0.7"
+bevy_state_ui = "0.8"
 ```
 
-## Example
+## Usage
 
-Here’s a minimal app with clickable text that increments a counter:
+1. Define a state struct that implements `Resource`, `Debug`, and `StateRender`:
 
-[examples/simple.rs](examples/simple.rs)
+```rust
+#[derive(Resource, Debug, Default)]
+struct GameState {
+    count: usize,
+}
 
-Run it with:
+impl StateRender for GameState {
+    fn render(&self, mut commands: EntityCommands) {
+        commands
+            .insert(Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                ..default()
+            })
+            .with_children(|parent| {
+                parent.spawn(Text::new(format!("Count: {}", self.count)));
+            });
+    }
+}
+```
+
+2. Add the plugin and insert your resource whenever you're ready:
+
+```rust
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(BevyStateUiPlugin::<GameState>::default())
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+    commands.init_resource::<GameState>();
+}
+```
+
+The resource doesn't need to exist at startup. The plugin handles `Option<Res<T>>`, so you can insert or remove the resource at any time and the UI will appear or disappear accordingly.
+
+### Debug logging
+
+Chain `.debug()` to log state changes to stdout:
+
+```rust
+.add_plugins(BevyStateUiPlugin::<GameState>::default().debug())
+```
+
+### Full example
+
+See [examples/simple.rs](examples/simple.rs). Run it with:
 
 ```bash
 cargo run --example simple
 ```
 
-## Why use this instead of plain Bevy UI?
-
-Normally in Bevy, building UI means:
-
-- Spawning a hierarchy of `Node`/`Text`/`Button` entities in startup systems.
-- Keeping track of `Entity` IDs or `Querys` to update them later.
-- Writing update logic that mutates styles, colors, and text when game state changes.
-
-This often leads to boilerplate and imperative code. For example:
-
-- You check a `Res<State>` inside systems.
-- You manually update the `BackgroundColor` of a button when `state.hovered` changes.
-- You may need to despawn/respawn UI trees when state transitions are large.
-
-With bevy_state_ui, you flip the model:
-
-- Define your UI as a pure function of state (`impl StateRender for State`).
-- The library automatically detects when state changes (via hashing).
-- The old UI is despawned and re-rendered from the new state.
-
-This means:
-
-✅ Less boilerplate
-✅ More predictable UI (no stale entity state)
-✅ A workflow similar to React/Elm/SwiftUI for Bevy
-
-If your mental model of UI is "render(state) → tree of UI nodes", this library gives you exactly that.
-
 ## How it works
 
-- You define a `State` struct that implements:
-  - `Resource` (so it can live in the ECS world).
-  - `Hash` (to efficiently detect when state changes).
-  - `StateRender` (your declarative UI description).
-- The system `ui_state_render::<State>`:
-  - Computes a hash of the state each frame.
-  - If it changed, despawns the previous UI root and calls your `render` function.
-  - Keeps the UI automatically in sync with your state.
+- `BevyStateUiPlugin<T>` registers an `Update` system for your state type.
+- Each frame, the system checks `Res<T>::is_changed()`.
+- If the state changed, the previous root UI entity is despawned and `StateRender::render` is called to rebuild the UI tree.
+- If the resource is removed, the UI is despawned and nothing is rendered.
 
-This lets you think of UI as a pure function of state, much like React, Elm, or SwiftUI.
+## When not to use this
+
+This plugin takes a full teardown-and-rebuild approach to UI updates. This is a deliberate tradeoff for simplicity, but it comes with limitations:
+
+- **Frequent state changes** - If your state updates every frame (e.g. a real-time HUD tracking position, health, scores, etc.), the entire UI tree is despawned and respawned every frame. For large or deep UI hierarchies, this can be expensive.
+- **Animations and transitions** - Since the UI is rebuilt from scratch on each change, there is no continuity between frames. CSS-like transitions or entity-based animations won't carry over.
+- **Large UI trees** - The cost of despawn/respawn scales with the size of the UI hierarchy. For complex layouts with many nodes, the overhead may be noticeable.
+
+This plugin works best for UI that changes infrequently in response to discrete events (menu screens, settings panels, inventory views, dialogue boxes, etc.) rather than UI that needs to update continuously.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,37 +1,26 @@
-use bevy::{prelude::*, window::PresentMode};
+use bevy::prelude::*;
 use bevy_state_ui::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Simple'".to_string(),
-                present_mode: PresentMode::Immediate,
-                ..default()
-            }),
-            ..default()
-        }),))
+        .add_plugins(DefaultPlugins)
+        .add_plugins(BevyStateUiPlugin::<GameState>::default().debug())
         .add_systems(Startup, setup)
-        .add_systems(Update, ui_state_render::<State>)
-        .register_ui_state::<State>()
         .run();
 }
 
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
-    commands.init_resource::<State>();
+    commands.init_resource::<GameState>();
 }
 
-#[derive(Resource, Hash, Debug, Default)]
-pub struct State {
-    pub count: u128,
+#[derive(Resource, Debug, Default)]
+struct GameState {
+    count: usize,
 }
 
-impl StateRender for State {
+impl StateRender for GameState {
     fn render(&self, mut commands: EntityCommands) {
-        info!("UI Rendered!");
-        info!("{self:?}");
-
         commands
             .insert(Node {
                 width: Val::Percent(100.0),
@@ -75,6 +64,6 @@ impl StateRender for State {
     }
 }
 
-fn on_click(_click: On<Pointer<Click>>, mut state: ResMut<State>) {
+fn on_click(_click: On<Pointer<Click>>, mut state: ResMut<GameState>) {
     state.count += 1;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,85 +1,117 @@
-use std::{
-    hash::{BuildHasher, Hash},
-    marker::PhantomData,
-};
+use std::marker::PhantomData;
 
-use bevy::{diagnostic::FrameCount, platform::hash::FixedState, prelude::*};
+use bevy::prelude::*;
 
 pub mod prelude {
-    pub use crate::{ui_state_render, StateRender, StateUiAppExt};
+    pub use crate::BevyStateUiPlugin;
+    pub use crate::StateRender;
 }
 
+/// Marker component for the root UI entity managed by the plugin.
 #[derive(Component)]
-pub struct RootNode<T> {
+struct RootNode<T> {
     phantom: PhantomData<T>,
 }
 
+/// Implement this trait on a [`Resource`] to define how it renders as UI.
+///
+/// The provided [`EntityCommands`] refers to the root entity that the plugin
+/// spawns. Insert UI components and children from here.
 pub trait StateRender {
     fn render(&self, commands: EntityCommands);
 }
 
+/// Marker resource inserted when debug logging is enabled for a state type.
 #[derive(Resource)]
-pub struct RenderedHash<T> {
+struct DebugStateRender<T> {
     phantom: PhantomData<T>,
-    last_frame_check: u32,
-    last_hash_value: u64,
 }
 
-pub trait StateUiAppExt {
-    fn register_ui_state<TState>(&mut self) -> &mut Self
-    where
-        TState: Resource;
+/// A Bevy plugin that re-renders UI whenever a [`Resource`] of type `T` changes.
+///
+/// The plugin registers an [`Update`] system that uses Bevy's change detection
+/// to determine when `T` has been modified. On change, the existing root UI
+/// entity is despawned and [`StateRender::render`] is called to rebuild it.
+///
+/// The resource does not need to exist at startup. The system handles
+/// `Option<Res<T>>`, so the resource can be inserted or removed at any time.
+///
+/// # Usage
+/// ```no_run
+/// app.add_plugins(BevyStateUiPlugin::<MyState>::default());
+/// ```
+///
+/// Enable debug logging with the builder method:
+/// ```no_run
+/// app.add_plugins(BevyStateUiPlugin::<MyState>::default().debug());
+/// ```
+pub struct BevyStateUiPlugin<T: Resource + std::fmt::Debug + StateRender> {
+    phantom: PhantomData<T>,
+    debug: bool,
 }
 
-impl StateUiAppExt for App {
-    fn register_ui_state<TState>(&mut self) -> &mut Self
-    where
-        TState: Resource,
-    {
-        self.insert_resource(RenderedHash::<TState> {
-            phantom: PhantomData,
-            last_frame_check: 0,
-            last_hash_value: 0,
-        });
+impl<T: Resource + std::fmt::Debug + StateRender> BevyStateUiPlugin<T> {
+    /// Enables debug logging. When active, prints the state value to stdout
+    /// each time the UI is re-rendered.
+    pub fn debug(mut self) -> Self {
+        self.debug = true;
         self
     }
 }
 
-pub fn ui_state_render<TState>(
+impl<T: Resource + std::fmt::Debug + StateRender> Plugin for BevyStateUiPlugin<T> {
+    fn build(&self, app: &mut App) {
+        if self.debug {
+            app.insert_resource(DebugStateRender::<T> {
+                phantom: PhantomData,
+            });
+        }
+        app.add_systems(Update, ui_state_render::<T>);
+    }
+}
+
+impl<T: Resource + std::fmt::Debug + StateRender> Default for BevyStateUiPlugin<T> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+            debug: false,
+        }
+    }
+}
+
+/// System that re-renders UI when the state resource changes.
+///
+/// If the resource is removed, the root entity is despawned (clearing the UI).
+/// If the resource exists and has changed since the last run, the old root
+/// entity is despawned and a new one is spawned via [`StateRender::render`].
+fn ui_state_render<T>(
     mut commands: Commands,
-    frame_count: Res<FrameCount>,
-    mut hash: ResMut<RenderedHash<TState>>,
-    state: Option<Res<TState>>,
-    q_root: Query<Entity, With<RootNode<TState>>>,
+    state: Option<Res<T>>,
+    debug: Option<Res<DebugStateRender<T>>>,
+    root: Query<Entity, With<RootNode<T>>>,
 ) where
-    TState: Resource + Hash + StateRender,
+    T: Resource + std::fmt::Debug + StateRender,
 {
     let Some(state) = state else {
-        for entity in q_root.iter() {
+        for entity in root.iter() {
             commands.entity(entity).despawn();
         }
-        hash.last_hash_value = 0;
         return;
     };
 
-    if hash.last_frame_check == frame_count.0 {
+    if state.is_changed() {
+        if debug.is_some() {
+            println!("[View Rendered] {:?}", state.as_ref());
+        }
+    } else {
         return;
     }
 
-    let value = FixedState::default().hash_one(&*state);
-
-    if hash.last_hash_value == value {
-        return;
-    }
-
-    hash.last_frame_check = frame_count.0;
-    hash.last_hash_value = value;
-
-    for entity in q_root.iter() {
+    for entity in root.iter() {
         commands.entity(entity).despawn();
     }
 
-    let commands = commands.spawn(RootNode::<TState> {
+    let commands = commands.spawn(RootNode::<T> {
         phantom: PhantomData,
     });
 


### PR DESCRIPTION
Migrate from manual hashing to Bevy's built-in change detection

# lib.rs
- Use Res<T>::is_changed() instead of manually hashing the state resource.
  This also eliminates the frame count guard, as Bevy's change detection
  already prevents redundant runs within the same frame.
- Remove the Hash trait bound, which causes issues with unhashable types
  like f32 that require manual workarounds by the user.
- Convert to a Plugin with a .debug() builder method for opt-in state
  logging on re-render.
- Remove RenderedHash resource, StateUiAppExt trait, and register_ui_state
  in favor of the plugin handling setup.
- Make RootNode private since it is an internal implementation detail.
- Add doc comments.

# example simple.rs
- Use new Plugin approach.
- Rename State to GameState.
- Remove unnecessary PresentMode::Immediate and pub visibility.
- Change count from u128 to usize.

# Cargo.toml
bump version

# README.md
- General overhaul
- Add a disclaimer, as this UI approach can be detrimental for certain apps.